### PR TITLE
Added -L to curl to account for github API redirects

### DIFF
--- a/cloud-config/azure/cloud-config.yml
+++ b/cloud-config/azure/cloud-config.yml
@@ -54,7 +54,7 @@ write_files:
     permissions: '0755'
     content: |
       #!/bin/sh
-      curl -sS https://api.github.com/repos/opendatakit/aggregate-cli/releases/latest \
+      curl -sSL https://api.github.com/repos/opendatakit/aggregate-cli/releases/latest \
       | grep "aggregate-cli.zip" \
       | cut -d: -f 2,3 \
       | tr -d \" \


### PR DESCRIPTION
Very small change because GitHub started redirecting its API calls. I've confirmed this works while setting up a test Aggregate server on Azure today.
