### PR TITLE
Instruct curl to follow redirects

### DIFF
--- a/cloud-config/aws/cloud-config.yml
+++ b/cloud-config/aws/cloud-config.yml
@@ -55,7 +55,7 @@ write_files:
     permissions: '0755'
     content: |
       #!/bin/sh
-      curl -sS https://api.github.com/repos/opendatakit/aggregate-cli/releases/latest \
+      curl -sSL https://api.github.com/repos/opendatakit/aggregate-cli/releases/latest \
       | grep "aggregate-cli.zip" \
       | cut -d: -f 2,3 \
       | tr -d \" \

--- a/cloud-config/azure/cloud-config.yml
+++ b/cloud-config/azure/cloud-config.yml
@@ -54,7 +54,7 @@ write_files:
     permissions: '0755'
     content: |
       #!/bin/sh
-      curl -sS https://api.github.com/repos/opendatakit/aggregate-cli/releases/latest \
+      curl -sSL https://api.github.com/repos/opendatakit/aggregate-cli/releases/latest \
       | grep "aggregate-cli.zip" \
       | cut -d: -f 2,3 \
       | tr -d \" \

--- a/cloud-config/digital-ocean/cloud-config.yml
+++ b/cloud-config/digital-ocean/cloud-config.yml
@@ -54,7 +54,7 @@ write_files:
     permissions: '0755'
     content: |
       #!/bin/sh
-      curl -sS https://api.github.com/repos/opendatakit/aggregate-cli/releases/latest \
+      curl -sSL https://api.github.com/repos/opendatakit/aggregate-cli/releases/latest \
       | grep "aggregate-cli.zip" \
       | cut -d: -f 2,3 \
       | tr -d \" \

--- a/cloud-config/google-cloud/startup-script.sh
+++ b/cloud-config/google-cloud/startup-script.sh
@@ -75,7 +75,7 @@ curl -H"Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata
 sed -i -e 's/foo\.bar/'"$(cat /tmp/domain-name)"'/' /root/aggregate-config.json
 sed -i -e 's/foo\.bar/'"$(cat /tmp/domain-name)"'/' /etc/nginx/sites-enabled/aggregate
 
-curl -sS https://api.github.com/repos/opendatakit/aggregate-cli/releases/latest \
+curl -sSL https://api.github.com/repos/opendatakit/aggregate-cli/releases/latest \
 | grep "aggregate-cli.zip" \
 | cut -d: -f 2,3 \
 | tr -d \" \

--- a/cloud-config/virtualbox/cloud-config.tpl.yml
+++ b/cloud-config/virtualbox/cloud-config.tpl.yml
@@ -61,7 +61,7 @@ write_files:
     permissions: '0755'
     content: |
       #!/bin/sh
-      curl -sS https://api.github.com/repos/opendatakit/aggregate-cli/releases/latest \
+      curl -sSL https://api.github.com/repos/opendatakit/aggregate-cli/releases/latest \
       | grep "aggregate-cli.zip" \
       | cut -d: -f 2,3 \
       | tr -d \" \


### PR DESCRIPTION
We have renamed opendatakit/aggregate to getodk/aggregate. Web browsers follow the redirect by default, but curl doesn't unless you add `-L`. 