### PR TITLE
Skip slow unattended-upgrades install, ensure postgres can chdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ For more information see [here for Docker](docs/build-and-run-a-docker-image.md)
 
     (Linux and macOS)
     ```bash
-    sudo su postgres -c "psql -c \"CREATE ROLE aggregate WITH LOGIN PASSWORD 'aggregate'\""
-    sudo su postgres -c "psql -c \"CREATE DATABASE aggregate WITH OWNER aggregate\""
-    sudo su postgres -c "psql -c \"GRANT ALL PRIVILEGES ON DATABASE aggregate TO aggregate\""
-    sudo su postgres -c "psql -c \"CREATE SCHEMA aggregate\" aggregate"
-    sudo su postgres -c "psql -c \"ALTER SCHEMA aggregate OWNER TO aggregate\" aggregate"
-    sudo su postgres -c "psql -c \"GRANT ALL PRIVILEGES ON SCHEMA aggregate TO aggregate\" aggregate"
+    sudo su - postgres -c "psql -c \"CREATE ROLE aggregate WITH LOGIN PASSWORD 'aggregate'\""
+    sudo su - postgres -c "psql -c \"CREATE DATABASE aggregate WITH OWNER aggregate\""
+    sudo su - postgres -c "psql -c \"GRANT ALL PRIVILEGES ON DATABASE aggregate TO aggregate\""
+    sudo su - postgres -c "psql -c \"CREATE SCHEMA aggregate\" aggregate"
+    sudo su - postgres -c "psql -c \"ALTER SCHEMA aggregate OWNER TO aggregate\" aggregate"
+    sudo su - postgres -c "psql -c \"GRANT ALL PRIVILEGES ON SCHEMA aggregate TO aggregate\" aggregate"
     ```
 
     (Windows)

--- a/cloud-config/aws/cloud-config.yml
+++ b/cloud-config/aws/cloud-config.yml
@@ -73,7 +73,6 @@ write_files:
 runcmd:
   - download-aggregate-cli
 
-  - unattended-upgrades
   - apt-get -y autoremove
 
   - rm /etc/nginx/sites-enabled/default
@@ -85,12 +84,12 @@ runcmd:
   - apt-get -y install python-certbot-nginx
   - (crontab -l 2>/dev/null; echo "0 0 1 * * /usr/bin/certbot renew > /var/log/letsencrypt/letsencrypt.log") | crontab -
 
-  - su postgres -c "psql -c \"CREATE ROLE aggregate WITH LOGIN PASSWORD 'aggregate'\""
-  - su postgres -c "psql -c \"CREATE DATABASE aggregate WITH OWNER aggregate\""
-  - su postgres -c "psql -c \"GRANT ALL PRIVILEGES ON DATABASE aggregate TO aggregate\""
-  - su postgres -c "psql -c \"CREATE SCHEMA aggregate\" aggregate"
-  - su postgres -c "psql -c \"ALTER SCHEMA aggregate OWNER TO aggregate\" aggregate"
-  - su postgres -c "psql -c \"GRANT ALL PRIVILEGES ON SCHEMA aggregate TO aggregate\" aggregate"
+  - su - postgres -c "psql -c \"CREATE ROLE aggregate WITH LOGIN PASSWORD 'aggregate'\""
+  - su - postgres -c "psql -c \"CREATE DATABASE aggregate WITH OWNER aggregate\""
+  - su - postgres -c "psql -c \"GRANT ALL PRIVILEGES ON DATABASE aggregate TO aggregate\""
+  - su - postgres -c "psql -c \"CREATE SCHEMA aggregate\" aggregate"
+  - su - postgres -c "psql -c \"ALTER SCHEMA aggregate OWNER TO aggregate\" aggregate"
+  - su - postgres -c "psql -c \"GRANT ALL PRIVILEGES ON SCHEMA aggregate TO aggregate\" aggregate"
 
   - sed -i -e 's/foobar/'"$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone/ | sed 's/.$//')"'/' /root/.aws/config
   - aws ec2 describe-tags | grep "aggregate.hostname" | grep "$(curl -s http://169.254.169.254/latest/meta-data/instance-id)" | awk -F' ' '{print $5}' > /tmp/domain-name

--- a/cloud-config/azure/cloud-config.yml
+++ b/cloud-config/azure/cloud-config.yml
@@ -66,7 +66,6 @@ write_files:
 runcmd:
   - download-aggregate-cli
 
-  - unattended-upgrades
   - apt-get -y autoremove
 
   - rm /etc/nginx/sites-enabled/default
@@ -78,12 +77,12 @@ runcmd:
   - apt-get -y install python-certbot-nginx
   - (crontab -l 2>/dev/null; echo "0 0 1 * * /usr/bin/certbot renew > /var/log/letsencrypt/letsencrypt.log") | crontab -
 
-  - su postgres -c "psql -c \"CREATE ROLE aggregate WITH LOGIN PASSWORD 'aggregate'\""
-  - su postgres -c "psql -c \"CREATE DATABASE aggregate WITH OWNER aggregate\""
-  - su postgres -c "psql -c \"GRANT ALL PRIVILEGES ON DATABASE aggregate TO aggregate\""
-  - su postgres -c "psql -c \"CREATE SCHEMA aggregate\" aggregate"
-  - su postgres -c "psql -c \"ALTER SCHEMA aggregate OWNER TO aggregate\" aggregate"
-  - su postgres -c "psql -c \"GRANT ALL PRIVILEGES ON SCHEMA aggregate TO aggregate\" aggregate"
+  - su - postgres -c "psql -c \"CREATE ROLE aggregate WITH LOGIN PASSWORD 'aggregate'\""
+  - su - postgres -c "psql -c \"CREATE DATABASE aggregate WITH OWNER aggregate\""
+  - su - postgres -c "psql -c \"GRANT ALL PRIVILEGES ON DATABASE aggregate TO aggregate\""
+  - su - postgres -c "psql -c \"CREATE SCHEMA aggregate\" aggregate"
+  - su - postgres -c "psql -c \"ALTER SCHEMA aggregate OWNER TO aggregate\" aggregate"
+  - su - postgres -c "psql -c \"GRANT ALL PRIVILEGES ON SCHEMA aggregate TO aggregate\" aggregate"
 
   - curl -H Metadata:true "http://169.254.169.254/metadata/instance/compute/tags?api-version=2017-08-01&format=text" | awk -F':' '{print $2}' > /tmp/domain-name
   - sed -i -e 's/foo\.bar/'"$(cat /tmp/domain-name)"'/' /root/aggregate-config.json

--- a/cloud-config/digital-ocean/cloud-config.yml
+++ b/cloud-config/digital-ocean/cloud-config.yml
@@ -67,7 +67,6 @@ runcmd:
   - download-aggregate-cli
 
   - apt-get -y remove openjdk-11-jre-headless
-  - unattended-upgrades
   - apt-get -y autoremove
 
   - rm /etc/nginx/sites-enabled/default
@@ -79,12 +78,12 @@ runcmd:
   - apt-get -y install python-certbot-nginx
   - (crontab -l 2>/dev/null; echo "0 0 1 * * /usr/bin/certbot renew > /var/log/letsencrypt/letsencrypt.log") | crontab -
 
-  - su postgres -c "psql -c \"CREATE ROLE aggregate WITH LOGIN PASSWORD 'aggregate'\""
-  - su postgres -c "psql -c \"CREATE DATABASE aggregate WITH OWNER aggregate\""
-  - su postgres -c "psql -c \"GRANT ALL PRIVILEGES ON DATABASE aggregate TO aggregate\""
-  - su postgres -c "psql -c \"CREATE SCHEMA aggregate\" aggregate"
-  - su postgres -c "psql -c \"ALTER SCHEMA aggregate OWNER TO aggregate\" aggregate"
-  - su postgres -c "psql -c \"GRANT ALL PRIVILEGES ON SCHEMA aggregate TO aggregate\" aggregate"
+  - su - postgres -c "psql -c \"CREATE ROLE aggregate WITH LOGIN PASSWORD 'aggregate'\""
+  - su - postgres -c "psql -c \"CREATE DATABASE aggregate WITH OWNER aggregate\""
+  - su - postgres -c "psql -c \"GRANT ALL PRIVILEGES ON DATABASE aggregate TO aggregate\""
+  - su - postgres -c "psql -c \"CREATE SCHEMA aggregate\" aggregate"
+  - su - postgres -c "psql -c \"ALTER SCHEMA aggregate OWNER TO aggregate\" aggregate"
+  - su - postgres -c "psql -c \"GRANT ALL PRIVILEGES ON SCHEMA aggregate TO aggregate\" aggregate"
 
   - sed -i -e 's/foo\.bar/'"$(curl -s http://169.254.169.254/metadata/v1/hostname)"'/' /root/aggregate-config.json
   - sed -i -e 's/foo\.bar/'"$(curl -s http://169.254.169.254/metadata/v1/hostname)"'/' /etc/nginx/sites-enabled/aggregate

--- a/cloud-config/google-cloud/startup-script.sh
+++ b/cloud-config/google-cloud/startup-script.sh
@@ -49,15 +49,14 @@ apt-get -y install \
 
 apt-get -y remove openjdk-11-jre-headless
 
-unattended-upgrades
 apt-get -y autoremove
 
-su postgres -c "psql -c \"CREATE ROLE aggregate WITH LOGIN PASSWORD 'aggregate'\""
-su postgres -c "psql -c \"CREATE DATABASE aggregate WITH OWNER aggregate\""
-su postgres -c "psql -c \"GRANT ALL PRIVILEGES ON DATABASE aggregate TO aggregate\""
-su postgres -c "psql -c \"CREATE SCHEMA aggregate\" aggregate"
-su postgres -c "psql -c \"ALTER SCHEMA aggregate OWNER TO aggregate\" aggregate"
-su postgres -c "psql -c \"GRANT ALL PRIVILEGES ON SCHEMA aggregate TO aggregate\" aggregate"
+su - postgres -c "psql -c \"CREATE ROLE aggregate WITH LOGIN PASSWORD 'aggregate'\""
+su - postgres -c "psql -c \"CREATE DATABASE aggregate WITH OWNER aggregate\""
+su - postgres -c "psql -c \"GRANT ALL PRIVILEGES ON DATABASE aggregate TO aggregate\""
+su - postgres -c "psql -c \"CREATE SCHEMA aggregate\" aggregate"
+su - postgres -c "psql -c \"ALTER SCHEMA aggregate OWNER TO aggregate\" aggregate"
+su - postgres -c "psql -c \"GRANT ALL PRIVILEGES ON SCHEMA aggregate TO aggregate\" aggregate"
 
 rm /etc/nginx/sites-enabled/default
 cat << EOF > /etc/nginx/sites-enabled/aggregate

--- a/cloud-config/virtualbox/cloud-config.tpl.yml
+++ b/cloud-config/virtualbox/cloud-config.tpl.yml
@@ -74,18 +74,17 @@ runcmd:
   - download-aggregate-cli
 
   - apt-get -y remove openjdk-11-jre-headless
-  - unattended-upgrades
   - apt-get -y autoremove
 
   - rm /etc/nginx/sites-enabled/default
   - mv /tmp/nginx-aggregate /etc/nginx/sites-enabled/aggregate
 
-  - su postgres -c "psql -c \"CREATE ROLE aggregate WITH LOGIN PASSWORD 'aggregate'\""
-  - su postgres -c "psql -c \"CREATE DATABASE aggregate WITH OWNER aggregate\""
-  - su postgres -c "psql -c \"GRANT ALL PRIVILEGES ON DATABASE aggregate TO aggregate\""
-  - su postgres -c "psql -c \"CREATE SCHEMA aggregate\" aggregate"
-  - su postgres -c "psql -c \"ALTER SCHEMA aggregate OWNER TO aggregate\" aggregate"
-  - su postgres -c "psql -c \"GRANT ALL PRIVILEGES ON SCHEMA aggregate TO aggregate\" aggregate"
+  - su - postgres -c "psql -c \"CREATE ROLE aggregate WITH LOGIN PASSWORD 'aggregate'\""
+  - su - postgres -c "psql -c \"CREATE DATABASE aggregate WITH OWNER aggregate\""
+  - su - postgres -c "psql -c \"GRANT ALL PRIVILEGES ON DATABASE aggregate TO aggregate\""
+  - su - postgres -c "psql -c \"CREATE SCHEMA aggregate\" aggregate"
+  - su - postgres -c "psql -c \"ALTER SCHEMA aggregate OWNER TO aggregate\" aggregate"
+  - su - postgres -c "psql -c \"GRANT ALL PRIVILEGES ON SCHEMA aggregate TO aggregate\" aggregate"
 
   - aggregate-cli -i -ip -y -c /root/aggregate-config.json
 

--- a/packer/ansible/roles/unattended-upgrades/tasks/main.yml
+++ b/packer/ansible/roles/unattended-upgrades/tasks/main.yml
@@ -4,6 +4,3 @@
   apt:
     pkg: unattended-upgrades
     state: installed
-
-- name: run security-updates
-  command: unattended-upgrades -v


### PR DESCRIPTION
* Ensure postgres can chdir or you get a "could not change directory to "/root": Permission denied" error. See https://stackoverflow.com/questions/35782366 for alternatives.
* Do not run unattended-upgrades because it's very slow (especially on DO) and blocks the rest of the install. The OS will run it eventually.

The PR itself doesn't require a new release (which is great). And it's relatively safe because if installs fail, we'll likely get support requests and we can respond then.

I did a search for "unattended-upgrade" and "postgres -c" to make sure I didn't miss anything.