### PR TITLE
Move maintenance status up top, link to Github repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
-# ODK Aggregate
+# ⚠️ ODK Aggregate is not actively maintained ⚠️
+
+We are no longer doing active maintenance on ODK Aggregate. The recommended replacement is [ODK Central](https://github.com/getodk/central). Central is fast, actively-developed, and addresses many of the issues that users have had with Aggregate over the years. Fixes and small improvements to Aggregate are welcome, but please discuss in an issue or [on the forum](https://forum.getodk.org/c/development/5) first to make sure that a reviewer will be available.
+
+## Overview
 ![Platform](https://img.shields.io/badge/platform-Java-blue.svg)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Build status](https://circleci.com/gh/getodk/aggregate.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/getodk/aggregate)
 [![Slack](https://img.shields.io/badge/chat-on%20slack-brightgreen)](https://slack.getodk.org)
-
-## ⚠️ Aggregate is no longer actively developed ⚠️
-The recommended ODK server is now [ODK Central](https://docs.getodk.org/central-intro/). Central is fast, actively-developed, and addresses many of the issues that users have had with Aggregate over the years. Fixes and small improvements to Aggregate are welcome, but please discuss in an issue or [on the forum](https://forum.getodk.org/c/development/5) first to make sure that a reviewer will be available.
 
 ODK Aggregate provides a ready-to-deploy server and database to:
 


### PR DESCRIPTION
I think it's better not to bury the lede. I also prefer this structure because it clearly separates the existing "overview" content about Aggregate in the same place. Note that I changed the link to Central to point to Github because my assumption is that people who come to this README are programmers.